### PR TITLE
Fix Parameter Encoding for OAuth

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -100,7 +100,7 @@
             apply: function(obj) {
               log(obj);
 
-              var oauth_stuff = create_oauth_stuff(obj.method, obj.url);
+              var oauth_stuff = create_oauth_stuff(obj.method, decodeURIComponent(obj.url));
 
               obj.headers.authorization = 'OAuth ' + 
                 'oauth_consumer_key="' + oauth_stuff.consumer_key + '", ' +

--- a/src/main/html/index.html
+++ b/src/main/html/index.html
@@ -100,7 +100,7 @@
             apply: function(obj) {
               log(obj);
 
-              var oauth_stuff = create_oauth_stuff(obj.method, obj.url);
+              var oauth_stuff = create_oauth_stuff(obj.method, decodeURIComponent(obj.url));
 
               obj.headers.authorization = 'OAuth ' + 
                 'oauth_consumer_key="' + oauth_stuff.consumer_key + '", ' +


### PR DESCRIPTION
Update the OAuth encoding scheme to ensure that all parameters are first
decoded (rendering the non-encoded characters prior to OAuth principles
applied, which include encoding). This avoids double-encoding
characters, which results in badness.
