### PR TITLE
Fix POST Parameter Double-Encoding Issue

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -62,7 +62,7 @@
 
       // parse POST parameters
       if (obj.method == "POST" && obj.headers["Content-Type"] == "application/x-www-form-urlencoded") {
-        params = params.concat(obj.body.split("&"));
+        params = params.concat(decodeURIComponent(obj.body).split("&"));
       }
 
       params = params.sort();

--- a/src/main/html/index.html
+++ b/src/main/html/index.html
@@ -62,7 +62,7 @@
 
       // parse POST parameters
       if (obj.method == "POST" && obj.headers["Content-Type"] == "application/x-www-form-urlencoded") {
-        params = params.concat(obj.body.split("&"));
+        params = params.concat(decodeURIComponent(obj.body).split("&"));
       }
 
       params = params.sort();


### PR DESCRIPTION
Update the POST functionality to ensure that all parameters are first
decoded from the body of the POST message prior to attempting to
construct the OAuth 1.0a signature. This ensures that any special
characters included with POST parameters are not double-encoded.
