### PR TITLE
Fix Type Parsing when Nil Returned

### DIFF
--- a/dist/swagger-ui.js
+++ b/dist/swagger-ui.js
@@ -2001,8 +2001,8 @@ SuperagentHttpClient.prototype.execute = function (obj) {
 
     if (err && obj.on && obj.on.error) {
       response.obj = err;
-      response.status = res ? res.status : 500;
-      response.statusText = res ? res.text : err.message;
+      response.status = (typeof(res) === "undefined" || typeof(res.status) === "undefined") ? 500 : res.status;
+      response.statusText = (typeof(res) === "undefined" || typeof(res.text) === "undefined") ? err.message : res.text;
       cb = obj.on.error;
     } else if (res && obj.on && obj.on.response) {
       response.obj = (typeof res.body !== 'undefined') ? res.body : res.text;


### PR DESCRIPTION
Update the JavaScript handling of responses to ensure that when a
response is received from the endpoint, if it is undefined, a default
and generic 500 error is returned along with the corresponding error
message. Otherwise, zero and nil are displayed for the status code and
body, respectively.
